### PR TITLE
add the possibility to install with Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ https://github.com/PHPMailer/PHPMailer/issues/751
 https://bugs.oxid-esales.com/view.php?id=6468
 
 ## installation
+### with Composer
+    $ php composer config repositories.vt vcs https://github.com/vanilla-thunder/fix-phpmailer
+    $ php composer require vanilla-thunder/fix-phpmailer:"dev-master" --update-no-dev
+### or with git
     $ cd modules
     $ git clone https://github.com/vanilla-thunder/fix-phpmailer.git
-or
+### or manually
  * download zip  
  * rename "fix-phpmailer-master" to "fix-phpmailer"  
  * upload "fix-phpmailer" into modules/ directory

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+  "name": "vanilla-thunder/fix-phpmailer",
+  "description": "Fix for OXID eShop: PHPMailer bug #751",
+  "type": "oxideshop-module",
+  "keywords": [
+    "oxid",
+    "modules",
+    "eShop",
+    "phpmailer",
+    "body",
+    "corrupt"
+  ],
+  "require": {
+    "oxid-esales/oxideshop-ce": "*"
+  },
+  "extra": {
+    "oxideshop": {
+      "target-directory": "vt/fix-phpmailer"
+    }
+  }
+}


### PR DESCRIPTION
For a smooth installation, however, these changes would still help:

- Registration at packagist.org - avoids listing the repository as an additional source
- Creation of the version number tags - avoids referencing the master branch